### PR TITLE
3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [3.0.3] - 2024-07-19
+
+### Fixed
+
 - Fixes CSV maker helper to use file encoding option from args, when provided
 
 ## [3.0.2] - 2024-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes CSV maker helper to use file encoding option from args, when provided
+
 ## [3.0.2] - 2024-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perimetre/helpers",
   "description": "Our bundle with all of our utilities and reusable helpers",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/perimetre/helpers.git"

--- a/src/helpers/csv/index.ts
+++ b/src/helpers/csv/index.ts
@@ -134,7 +134,10 @@ export const parseCsv = <T>(
  */
 export const makeCsv = async (dir: string, name: string, content: Input, opts: Options = {}, append = false) =>
   new Promise<void>((resolve, reject) => {
-    const writeStream = fs.createWriteStream(path.join(dir, name), { flags: append ? 'a' : 'w', encoding: 'utf8' });
+    const writeStream = fs.createWriteStream(path.join(dir, name), {
+      flags: append ? 'a' : 'w',
+      encoding: opts.encoding || 'utf8'
+    });
 
     stringify(content, opts)
       .on('data', (chunk) => {


### PR DESCRIPTION
- **fix: for csv maker helper to use file encoding provided in options, when provided**
- **build: bumping version: 3.0.3**
